### PR TITLE
Add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+node_modules
 


### PR DESCRIPTION
Everybody will have node_modules, so it's better to ignore it.

If your project has a policy that discourages adding such things to .gitignore, ignore this pull request.
