### PR TITLE
Add 'use strict' to the main RTLText function

### DIFF
--- a/src/RTLText.module.js
+++ b/src/RTLText.module.js
@@ -16,6 +16,8 @@
  * initial text.
  */
 var RTLText = function() {
+  'use strict';
+
   var that = {};
   var rtlThreshold = 0.3;
   var rtlChar = /[\u0600-\u06FF]|[\u0750-\u077F]|[\u0590-\u05FF]|[\uFE70-\uFEFF]/mg;


### PR DESCRIPTION
Now there are no undefined or non-strict-compliant code here, so 'use strict' should be used.

If your project has a reason not to enable strict mode, I would be curious to know it :)
