### PR TITLE
Rename $textBox to $textbox

### DIFF
--- a/tests/public/spec/RTLText.spec.js
+++ b/tests/public/spec/RTLText.spec.js
@@ -4,7 +4,7 @@ describe('tools to apply RTL rules to text entry', function () {
   var KEY_BACKSPACE = 8;
   var KEY_DELETE = 46;
   var KEY_RIGHT_ARROW = 39;
-  var $textBox;
+  var $textbox;
 
   beforeEach(function () {
     $textbox = $('<textarea id="textbox"></textarea>');


### PR DESCRIPTION
If I understand correctly, the variable that represents the element
that is used for the tests is called $textbox throughout the code,
so I changed the declaration accordingly.
