### PR TITLE
Return an empty string instead of undefined.

### DIFF
--- a/src/RTLText.module.js
+++ b/src/RTLText.module.js
@@ -209,7 +209,7 @@ var RTLText = function () {
   }
 
   function removeMarkers (text) {
-    return text ? text.replace(dirMark, '') : undefined;
+    return text ? text.replace(dirMark, '') : '';
   }
 
   function shouldBeRTL (plainText) {


### PR DESCRIPTION
Internal repos that use this module expect removeMarkers to return a string.
